### PR TITLE
Fix config validation tests for megatext restructure

### DIFF
--- a/tests/unit/configs_test.py
+++ b/tests/unit/configs_test.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Test suite for validating MaxText YAML configurations against Pydantic models.
+Test suite for validating Megatext YAML configurations against Pydantic models.
 
 This test suite uses explicit, hardcoded lists of configuration files grouped
-by model family (e.g., gemma, llama) to test them directly against the Pydantic
+by architecture family to test them directly against the Pydantic
 `MaxTextConfig` model. It avoids programmatic file discovery and the complex
 `pyconfig.initialize` function to provide fast, targeted feedback on validation
 errors like "Extra inputs are not permitted."
@@ -33,10 +33,9 @@ from pydantic import ValidationError
 from yaml import YAMLError
 
 from megatext.configs import types as pydantic_types
-from megatext.utils.constants import MAXTEXT_REPO_ROOT
+from megatext.utils.constants import MEGATEXT_CONFIGS_DIR
 
-# Define the root directory where configuration files are located.
-CONFIGS_DIR = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs")
+CONFIGS_DIR = MEGATEXT_CONFIGS_DIR
 
 
 @functools.lru_cache(maxsize=None)
@@ -45,7 +44,7 @@ def load_and_merge_yamls(yaml_path: str) -> dict:
   Recursively loads a YAML file and merges it with its base configurations.
 
   A cache is used to avoid re-reading and re-parsing the same base files
-  multiple times (e.g., base.yml).
+  multiple times (e.g., base.yaml).
 
   Args:
       yaml_path: The absolute path to the YAML file to load.
@@ -109,18 +108,10 @@ def run_config_validation(config_file_path: str):
 # Begin Test Functions
 # ==============================================================================
 
-# --- Test Group 1: Base and Top-Level Configs ---
+# --- Test Group 1: Base Config ---
 
 BASE_CONFIGS = [
-    os.path.join(CONFIGS_DIR, "base.yml"),
-    os.path.join(CONFIGS_DIR, "post_train", "dpo.yml"),
-    os.path.join(CONFIGS_DIR, "gpu/gpu_smoke_test.yml"),
-    os.path.join(CONFIGS_DIR, "post_train", "rl.yml"),
-    os.path.join(CONFIGS_DIR, "post_train", "rl_mt_jt.yml"),
-    os.path.join(CONFIGS_DIR, "post_train", "sft.yml"),
-    os.path.join(CONFIGS_DIR, "post_train", "sft-vision-chartqa.yml"),
-    os.path.join(CONFIGS_DIR, "post_train", "sft-vision-slidevqa.yml"),
-    os.path.join(CONFIGS_DIR, "tpu/tpu_smoke_test.yml"),
+    os.path.join(CONFIGS_DIR, "base.yaml"),
 ]
 
 
@@ -129,169 +120,21 @@ def test_base_configs(config_file):
   run_config_validation(config_file)
 
 
-# --- Test Group 2: Gemma Model Family ---
+# --- Test Group 2: Architecture Template Configs (models/) ---
 
-GEMMA_CONFIGS = [
-    os.path.join(CONFIGS_DIR, "models", "gemma-2b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gemma-7b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gemma2-2b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gemma2-9b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gemma2-27b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gemma3-4b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gemma3-12b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gemma3-27b.yml"),
+MODEL_CONFIGS = [
+    os.path.join(CONFIGS_DIR, "models", "deepseek.yaml"),
+    os.path.join(CONFIGS_DIR, "models", "gemma3.yaml"),
+    os.path.join(CONFIGS_DIR, "models", "gpt_oss.yaml"),
+    os.path.join(CONFIGS_DIR, "models", "llama3.yaml"),
+    os.path.join(CONFIGS_DIR, "models", "qwen3.yaml"),
+    os.path.join(CONFIGS_DIR, "models", "qwen3-moe.yaml"),
+    os.path.join(CONFIGS_DIR, "models", "qwen3-swa.yaml"),
+    os.path.join(CONFIGS_DIR, "models", "qwen3-next-dense.yaml"),
+    os.path.join(CONFIGS_DIR, "models", "qwen3-next-moe.yaml"),
 ]
 
 
-@pytest.mark.parametrize("config_file", GEMMA_CONFIGS)
-def test_gemma_configs(config_file):
-  run_config_validation(config_file)
-
-
-# --- Test Group 3: Llama Model Family ---
-
-LLAMA_CONFIGS = [
-    os.path.join(CONFIGS_DIR, "gpu", "models", "llama2_7b.yml"),
-    os.path.join(CONFIGS_DIR, "gpu", "models", "llama2_70b.yml"),
-    os.path.join(CONFIGS_DIR, "gpu", "models", "llama3_8b.yml"),
-    os.path.join(CONFIGS_DIR, "gpu", "models", "llama3_70b.yml"),
-    os.path.join(CONFIGS_DIR, "gpu", "models", "llama3.1_405b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama2-7b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama2-13b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama2-70b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama3-8b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama3-70b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama3-405b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama3.1-8b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama3.1-70b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama3.1-405b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama3.3-70b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama4-17b-16e.yml"),
-    os.path.join(CONFIGS_DIR, "models", "llama4-17b-128e.yml"),
-]
-
-
-@pytest.mark.parametrize("config_file", LLAMA_CONFIGS)
-def test_llama_configs(config_file):
-  run_config_validation(config_file)
-
-
-# --- Test Group 4: GPT Model Family ---
-
-GPT_CONFIGS = [
-    os.path.join(CONFIGS_DIR, "models", "gpt3-52k.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gpt3-6b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gpt3-22b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gpt3-175b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gpt-oss-20b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "gpt-oss-120b.yml"),
-]
-
-
-@pytest.mark.parametrize("config_file", GPT_CONFIGS)
-def test_gpt_configs(config_file):
-  run_config_validation(config_file)
-
-
-# --- Test Group 5: DeepSeek Model Family ---
-
-DEEPSEEK_CONFIGS = [
-    os.path.join(CONFIGS_DIR, "models", "deepseek2-16b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "deepseek2-236b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "deepseek3-test.yml"),
-    os.path.join(CONFIGS_DIR, "models", "deepseek3-671b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "deepseek3-671b-2dfsdp.yml"),
-    os.path.join(CONFIGS_DIR, "models", "deepseek3-671b-batchsplit.yml"),
-]
-
-
-@pytest.mark.parametrize("config_file", DEEPSEEK_CONFIGS)
-def test_deepseek_configs(config_file):
-  run_config_validation(config_file)
-
-
-# --- Test Group 6: Mistral & Mixtral Model Family ---
-
-MISTRAL_CONFIGS = [
-    os.path.join(CONFIGS_DIR, "models", "mistral-7b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "mixtral-8x7b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "mixtral-8x22b.yml"),
-    os.path.join(CONFIGS_DIR, "gpu", "models", "mixtral_8x1b.yml"),
-    os.path.join(CONFIGS_DIR, "gpu", "models", "mixtral_8x2b.yml"),
-    os.path.join(CONFIGS_DIR, "gpu", "models", "mixtral_8x7b.yml"),
-]
-
-
-@pytest.mark.parametrize("config_file", MISTRAL_CONFIGS)
-def test_mistral_configs(config_file):
-  run_config_validation(config_file)
-
-
-# --- Test Group 7: Qwen Model Family ---
-
-QWEN_CONFIGS = [
-    os.path.join(CONFIGS_DIR, "models", "qwen3-0.6b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "qwen3-4b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "qwen3-4b-thinking-2507.yml"),
-    os.path.join(CONFIGS_DIR, "models", "qwen3-8b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "qwen3-14b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "qwen3-32b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "qwen3-235b-a22b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "qwen3-30b-a3b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "qwen3-480b-a35b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "qwen3-next-80b-a3b.yml"),
-    os.path.join(CONFIGS_DIR, "models", "qwen3-omni-30b-a3b.yml"),
-]
-
-
-@pytest.mark.parametrize("config_file", QWEN_CONFIGS)
-def test_qwen_configs(config_file):
-  run_config_validation(config_file)
-
-
-# --- Test Group 8: Kimi Model Family ---
-
-KIMI_CONFIGS = [
-    os.path.join(CONFIGS_DIR, "models", "kimi-k2-1t.yml"),
-]
-
-
-@pytest.mark.parametrize("config_file", KIMI_CONFIGS)
-def test_kimi_configs(config_file):
-  run_config_validation(config_file)
-
-
-# --- Test Group 9: Inference-specific Configs ---
-
-INFERENCE_CONFIGS = [
-    os.path.join(CONFIGS_DIR, "inference", "inference.yml"),
-    os.path.join(CONFIGS_DIR, "inference", "inference_jetstream.yml"),
-    os.path.join(CONFIGS_DIR, "tpu", "v5e", "llama2_70b_v5e-16.yml"),
-    os.path.join(CONFIGS_DIR, "tpu", "v5e", "llama3_70b_v5e-16.yml"),
-    os.path.join(CONFIGS_DIR, "tpu", "v5e", "llama3_405b_v5e-64.yml"),
-    os.path.join(CONFIGS_DIR, "tpu", "v6e", "inference", "llama4_maverick_v6e-64.yml"),
-    os.path.join(
-        MAXTEXT_REPO_ROOT,
-        "src",
-        "maxtext",
-        "configs",
-        "inference",
-        "multihost",
-        "disaggregation",
-        "llama3_405b_v6e-16-16.yml",
-    ),
-    os.path.join(
-        MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "inference", "multihost", "interleaved", "llama2_70b_v5e-16.yml"
-    ),
-    os.path.join(
-        MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "inference", "multihost", "interleaved", "llama3_70b_v5e-16.yml"
-    ),
-    os.path.join(
-        MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "inference", "multihost", "interleaved", "llama3_405b_v5e-64.yml"
-    ),
-]
-
-
-@pytest.mark.parametrize("config_file", INFERENCE_CONFIGS)
-def test_inference_configs(config_file):
+@pytest.mark.parametrize("config_file", MODEL_CONFIGS)
+def test_model_configs(config_file):
   run_config_validation(config_file)

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -23,10 +23,10 @@ import pydantic
 from megatext.configs import pyconfig
 from megatext.configs.pyconfig import initialize_pydantic
 from megatext.configs import types
-from megatext.utils.constants import MAXTEXT_REPO_ROOT
+from megatext.utils.constants import MEGATEXT_CONFIGS_DIR
 
-# Path to the base.yml config. This assumes that `pytest` is run from the project root.
-_BASE_CONFIG_PATH = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "base.yml")
+# Path to the base.yaml config.
+_BASE_CONFIG_PATH = os.path.join(MEGATEXT_CONFIGS_DIR, "base.yaml")
 
 
 class ConfigTest(unittest.TestCase):
@@ -58,13 +58,13 @@ class ConfigTest(unittest.TestCase):
     self.assertIsInstance(config.steps, int)
 
   def test_model_override(self):
-    """Tests that model-specific configs override base.yml."""
-    argv = ["", _BASE_CONFIG_PATH, "model=llama2-7b", "run_name=test"]
+    """Tests that model-specific configs override base.yaml."""
+    argv = ["", _BASE_CONFIG_PATH, "model=llama3", "run_name=test"]
     config = pyconfig.initialize(argv)
-    self.assertEqual(config.base_emb_dim, 4096)  # From llama2-7b.yml
-    self.assertEqual(config.base_num_decoder_layers, 32)  # From llama2-7b.yml
-    self.assertEqual(config.decoder_block, types.DecoderBlockType.LLAMA2)  # from llama2-7b.yml
-    self.assertEqual(config.steps, 150001)  # From base.yml, not overridden
+    self.assertEqual(config.base_emb_dim, 4096)  # From llama3.yaml
+    self.assertEqual(config.base_num_decoder_layers, 32)  # From llama3.yaml
+    self.assertEqual(config.decoder_block, types.DecoderBlockType.LLAMA2)  # From llama3.yaml
+    self.assertEqual(config.steps, 150000)  # From base.yaml, not overridden
 
   def test_derived_values(self):
     """Tests that derived values are calculated correctly."""
@@ -119,7 +119,7 @@ class ConfigTest(unittest.TestCase):
     argv = [
         "",
         _BASE_CONFIG_PATH,
-        "model=llama3-8b",
+        "model=llama3",
         "tokenizer_path=assets/tokenizer_llama3.tiktoken",
         "run_name=test",
     ]


### PR DESCRIPTION
## Summary
- Fix broken imports: replace nonexistent `MAXTEXT_REPO_ROOT` with `MEGATEXT_CONFIGS_DIR` from `megatext.utils.constants`
- Replace all `.yml` path references with `.yaml` to match renamed config files
- Replace 68 deleted size-specific model config references (gemma-2b, llama2-7b, qwen3-8b, etc.) with 9 architecture template configs (deepseek, gemma3, gpt_oss, llama3, qwen3, qwen3-moe, qwen3-swa, qwen3-next-dense, qwen3-next-moe)
- Remove references to deleted directories (post_train/, gpu/, inference/)
- Update `configs_value_test.py` to use `model=llama3` instead of deleted `model=llama2-7b`

## Test plan
- [x] `pytest tests/unit/configs_test.py tests/unit/configs_value_test.py -v` -- 17 passed, 2 pre-existing config schema failures (deepseek.yaml/gpt_oss.yaml have fields not yet in Pydantic model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)