### PR TITLE
Fix integration tests: update imports for megatext restructure

### DIFF
--- a/tests/integration/aot_identical_test.py
+++ b/tests/integration/aot_identical_test.py
@@ -27,8 +27,7 @@ import hashlib
 import re
 import jax
 from tests.utils.test_helpers import get_test_config_path
-from megatext.trainers.pre_train import train_compile
-from megatext.trainers.pre_train import train
+from megatext.trainers import pretrain
 
 
 class AotBaseTest(unittest.TestCase):
@@ -80,6 +79,7 @@ class AotBaseTest(unittest.TestCase):
     return h1.hexdigest() == h2.hexdigest()
 
 
+@pytest.mark.skip(reason="module removed in restructure: train_compile was deleted")
 class AotHloIdenticalTest(AotBaseTest):
   """Tests for Ahead of Time Compilation HLO Graph Verification."""
 
@@ -131,7 +131,7 @@ class AotHloIdenticalTest(AotBaseTest):
             "--xla_dump_hlo_module_re=jit_train_step",
         )
     )
-    train.main(train_argv)
+    pretrain.main(train_argv)
     shutil.move(local_landing_dir, train_dump_dir)
     jax.clear_caches()
 
@@ -158,6 +158,7 @@ class AotHloIdenticalTest(AotBaseTest):
     self.assert_compile_and_real_match_hlo("default_run")
 
 
+@pytest.mark.skip(reason="module removed in restructure: train_compile was deleted")
 class AotJaxprIdenticalTest(AotBaseTest):
   """Tests for Ahead of Time Compilation Jaxpr Verification."""
 
@@ -194,7 +195,7 @@ class AotJaxprIdenticalTest(AotBaseTest):
         get_test_config_path(),
         f"dump_jaxpr_local_dir={train_dump_dir}",
     ) + tuple(shared_args)
-    train.main(train_argv)
+    pretrain.main(train_argv)
     jax.clear_caches()
 
     # Run train_compile.py and dump jaxpr

--- a/tests/integration/smoke/inference_microbenchmark_smoke_test.py
+++ b/tests/integration/smoke/inference_microbenchmark_smoke_test.py
@@ -20,7 +20,7 @@ import unittest
 from absl.testing import absltest
 
 from megatext.configs import pyconfig
-from megatext.utils.constants import MAXTEXT_CONFIGS_DIR, MAXTEXT_ASSETS_ROOT
+from megatext.utils.constants import MEGATEXT_CONFIGS_DIR, MEGATEXT_ASSETS_ROOT
 from megatext.common.gcloud_stub import is_decoupled
 
 pytestmark = [pytest.mark.external_serving]
@@ -43,8 +43,8 @@ class Inference_Microbenchmark(unittest.TestCase):
     config = pyconfig.initialize(
         [
             None,
-            os.path.join(MAXTEXT_CONFIGS_DIR, "tpu", "tpu_smoke_test.yml"),
-            rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+            os.path.join(MEGATEXT_CONFIGS_DIR, "tpu", "tpu_smoke_test.yml"),
+            rf"tokenizer_path={os.path.join(MEGATEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
             "ici_autoregressive_parallelism=-1",
             "ici_fsdp_parallelism=1",
             "max_prefill_predict_length=1024",

--- a/tests/integration/smoke/train_gpu_smoke_test.py
+++ b/tests/integration/smoke/train_gpu_smoke_test.py
@@ -20,7 +20,7 @@ from absl.testing import absltest
 
 from megatext.common.gcloud_stub import is_decoupled
 from megatext.trainers.pretrain import main as train_main
-from megatext.utils.constants import MAXTEXT_ASSETS_ROOT
+from megatext.utils.constants import MEGATEXT_ASSETS_ROOT
 from tests.utils.test_helpers import get_test_dataset_path, get_test_base_output_directory, get_test_config_path
 
 
@@ -49,7 +49,7 @@ class Train(unittest.TestCase):
             "run_name=runner_test",
             r"dataset_path={self.dataset_path}",
             "enable_checkpointing=False",
-            rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
+            rf"tokenizer_path={os.path.join(MEGATEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
             "enable_goodput_recording=False",
             "enable_checkpoint_cloud_logger=False",
             "monitor_goodput=False",

--- a/tests/integration/smoke/train_using_ragged_dot_smoke_test.py
+++ b/tests/integration/smoke/train_using_ragged_dot_smoke_test.py
@@ -21,9 +21,9 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 from tests.utils.test_helpers import get_test_config_path
-from megatext.trainers.pre_train import train
+from megatext.trainers import pretrain
 
-train_main = train.main
+train_main = pretrain.main
 gettempdir = tempfile.gettempdir
 
 

--- a/tests/integration/xaot_test.py
+++ b/tests/integration/xaot_test.py
@@ -25,10 +25,10 @@ import os
 import shutil
 import jax
 from tests.utils.test_helpers import get_test_config_path
-from megatext.trainers.pre_train import train_compile
-from megatext.trainers.pre_train import train
+from megatext.trainers import pretrain
 
 
+@pytest.mark.skip(reason="module removed in restructure: train_compile was deleted")
 class CompileThenLoadTest(unittest.TestCase):
   """Tests for the Split Compile and Train workflow"""
 
@@ -115,7 +115,7 @@ class CompileThenLoadTest(unittest.TestCase):
     print(f"\n--- Starting Load/Train Step for {test_name} ---")
     # Clear caches before train to ensure we are actually loading from the pickle
     jax.clear_caches()
-    train.main(train_argv)
+    pretrain.main(train_argv)
 
     print(f"Successfully compiled and loaded for test {test_name}!")
 


### PR DESCRIPTION
## Summary
- Replace `megatext.trainers.pre_train` imports with `megatext.trainers.pretrain` in 3 test files
- Skip `AotHloIdenticalTest`, `AotJaxprIdenticalTest`, and `CompileThenLoadTest` classes that depend on deleted `train_compile` module
- Fix `MAXTEXT_*` constant references to `MEGATEXT_*` in `train_gpu_smoke_test.py` and `inference_microbenchmark_smoke_test.py`

## Test plan
- [x] All 5 files parse without syntax errors
- [ ] Integration tests require TPU -- skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)