### PR TITLE
qwen3-next: dense MLP when num_experts=0 (HF-aligned) + conversion

### DIFF
--- a/src/megatext/configs/models/qwen3-next.yaml
+++ b/src/megatext/configs/models/qwen3-next.yaml
@@ -1,6 +1,7 @@
 # model config for qwen3-next (dense)
 
 decoder_block: "qwen3_next"
+num_experts: 0  # 0 = dense MLP (no routed/shared experts); >0 uses the sparse MoE block
 mlp_activations: ["silu", "linear"]
 normalization_layer_epsilon: 1.0e-6
 enable_dropout: false

--- a/src/megatext/configs/types.py
+++ b/src/megatext/configs/types.py
@@ -560,7 +560,10 @@ class PagedAttention(BaseModel):
 class MoEGeneral(BaseModel):
   """General configuration for Mixture of Experts (MoE) layers."""
 
-  num_experts: PositiveInt = Field(1, description="The total number of experts in each MoE layer.")
+  num_experts: NonNegativeInt = Field(
+      1,
+      description="The total number of experts in each MoE layer. 0 selects a plain dense MLP.",
+  )
   num_experts_per_tok: PositiveInt = Field(1, description="The number of experts to route each token to.")
   capacity_factor: float = Field(-1.0, description="Expert capacity factor. If < 0, no token dropping.")
   load_balance_loss_weight: NonNegativeFloat = Field(0.0, description="Weight for the load balancing auxiliary loss.")
@@ -2188,12 +2191,11 @@ class MegaTextConfig(
             f"Engram vocab size mismatch: expected {self.engram_max_ngram_size - 1} (max_ngram_size - 1), "
             f"but got {self.engram_vocab_bases}."
         )
-    if self.decoder_block == DecoderBlockType.QWEN3_NEXT and self.num_experts == 1:
-      # Dense qwen3-next: the FFN block (routed + shared expert) reads
-      # moe_mlp_dim even in the single-expert case; mirror the dense mlp_dim
-      # so dense configs only need base_mlp_dim.
-      self.base_moe_mlp_dim = self.base_mlp_dim
-      self.moe_mlp_dim = self.mlp_dim
+    if self.num_experts == 0 and self.decoder_block != DecoderBlockType.QWEN3_NEXT:
+      raise ValueError(
+          "num_experts=0 (dense MLP) is only supported for the qwen3-next decoder block; "
+          f"got decoder_block={self.decoder_block}."
+      )
     if self.num_experts > 1:
       is_fully_moe = (
           self.interleave_moe_layer_step == 1

--- a/src/megatext/conversion/models/qwen3_next.py
+++ b/src/megatext/conversion/models/qwen3_next.py
@@ -60,32 +60,41 @@ def build_qwen3_next(arch: ArchSpec, hf_config: Any, scan_layers: bool) -> Mappi
                 ("attention-out_proj-kernel", "linear_attn.out_proj.weight"),
             ])
 
-        # MoE regular components (all blocks)
-        comps.extend([
-            ("mlp-routed_experts-gate-kernel", "mlp.gate.weight"),
-            ("mlp-shared_expert-wi_0-kernel", "mlp.shared_expert.gate_proj.weight"),
-            ("mlp-shared_expert-wi_1-kernel", "mlp.shared_expert.up_proj.weight"),
-            ("mlp-shared_expert-wo-kernel", "mlp.shared_expert.down_proj.weight"),
-            ("mlp-shared_expert_gate-kernel", "mlp.shared_expert_gate.weight"),
-        ])
+        if n_experts == 0:
+            # Dense MLP (HF Qwen3NextMLP): plain SwiGLU, 1:1 like dense qwen3.
+            comps.extend([
+                ("mlp-wi_0-kernel", "mlp.gate_proj.weight"),
+                ("mlp-wi_1-kernel", "mlp.up_proj.weight"),
+                ("mlp-wo-kernel", "mlp.down_proj.weight"),
+            ])
+        else:
+            # MoE regular components (all blocks)
+            comps.extend([
+                ("mlp-routed_experts-gate-kernel", "mlp.gate.weight"),
+                ("mlp-shared_expert-wi_0-kernel", "mlp.shared_expert.gate_proj.weight"),
+                ("mlp-shared_expert-wi_1-kernel", "mlp.shared_expert.up_proj.weight"),
+                ("mlp-shared_expert-wo-kernel", "mlp.shared_expert.down_proj.weight"),
+                ("mlp-shared_expert_gate-kernel", "mlp.shared_expert_gate.weight"),
+            ])
 
         for mt_suffix, hf_suffix in comps:
             mt_key = f"{block_prefix}-{mt_suffix}"
             hf_keys = [f"{prefix}.layers.{i}.{hf_suffix}" for i in hf_indices]
             mapping[mt_key] = hf_keys
 
-        # Routed experts: fused gate_up_proj → composite (wi_0, wi_1)
-        mt_key = (
-            f"{block_prefix}-mlp-routed_experts-wi_0",
-            f"{block_prefix}-mlp-routed_experts-wi_1",
-        )
-        mapping[mt_key] = [
-            f"{prefix}.layers.{i}.mlp.experts.gate_up_proj" for i in hf_indices
-        ]
-        # Routed experts: down_proj (direct, 3D per layer)
-        mapping[f"{block_prefix}-mlp-routed_experts-wo"] = [
-            f"{prefix}.layers.{i}.mlp.experts.down_proj" for i in hf_indices
-        ]
+        if n_experts > 0:
+            # Routed experts: fused gate_up_proj → composite (wi_0, wi_1)
+            mt_key = (
+                f"{block_prefix}-mlp-routed_experts-wi_0",
+                f"{block_prefix}-mlp-routed_experts-wi_1",
+            )
+            mapping[mt_key] = [
+                f"{prefix}.layers.{i}.mlp.experts.gate_up_proj" for i in hf_indices
+            ]
+            # Routed experts: down_proj (direct, 3D per layer)
+            mapping[f"{block_prefix}-mlp-routed_experts-wo"] = [
+                f"{prefix}.layers.{i}.mlp.experts.down_proj" for i in hf_indices
+            ]
 
     return mapping
 
@@ -99,6 +108,7 @@ def build_qwen3_next_transforms(
     text_cfg = hf_config_dict.get("text_config", hf_config_dict)
     hidden_size = text_cfg.get("hidden_size", 0)
     vocab_size = text_cfg.get("vocab_size", 0)
+    n_experts = text_cfg.get("num_experts", text_cfg.get("num_local_experts", 0))
 
     transforms: dict[str, TransformFn] = {}
 
@@ -122,15 +132,21 @@ def build_qwen3_next_transforms(
     # Conv1d: axis permutation (K,1,C) ↔ (C,1,K)
     transforms["attention-conv1d-kernel"] = permute_conv
 
-    # MoE: router gate transpose, expert weights transpose
-    transforms["mlp-routed_experts-gate-kernel"] = tp
-    for suffix in [
-        "mlp-routed_experts-wi_0", "mlp-routed_experts-wi_1", "mlp-routed_experts-wo",
-        "mlp-shared_expert-wi_0-kernel", "mlp-shared_expert-wi_1-kernel",
-        "mlp-shared_expert-wo-kernel",
-        "mlp-shared_expert_gate-kernel",
-    ]:
-        transforms[suffix] = tp
+    if n_experts == 0:
+        # Dense MLP: SwiGLU kernels like dense qwen3.
+        transforms.update(_build_dense_kernel_transforms([
+            "mlp-wi_0-kernel", "mlp-wi_1-kernel", "mlp-wo-kernel",
+        ], to_hf))
+    else:
+        # MoE: router gate transpose, expert weights transpose
+        transforms["mlp-routed_experts-gate-kernel"] = tp
+        for suffix in [
+            "mlp-routed_experts-wi_0", "mlp-routed_experts-wi_1", "mlp-routed_experts-wo",
+            "mlp-shared_expert-wi_0-kernel", "mlp-shared_expert-wi_1-kernel",
+            "mlp-shared_expert-wo-kernel",
+            "mlp-shared_expert_gate-kernel",
+        ]:
+            transforms[suffix] = tp
 
     transforms.update(_build_embedding_transforms(arch, hidden_size, vocab_size, to_hf))
     transforms["logits_dense-kernel"] = _make_logits_transform(vocab_size, to_hf=to_hf)
@@ -208,14 +224,21 @@ def compute_qwen3_next_shapes(
             shapes[f"{bp}-attention-norm-rms_norm-scale"] = (*lp, gdn_vhd)
             shapes[f"{bp}-attention-out_proj-kernel"] = (*lp, value_dim, emb)
 
-        # MoE
-        shapes[f"{bp}-mlp-routed_experts-gate-kernel"] = (*lp, emb, n_experts)
-        shapes[f"{bp}-mlp-routed_experts-wi_0"] = (*lp, n_experts, emb, moe_mlp)
-        shapes[f"{bp}-mlp-routed_experts-wi_1"] = (*lp, n_experts, emb, moe_mlp)
-        shapes[f"{bp}-mlp-routed_experts-wo"] = (*lp, n_experts, moe_mlp, emb)
-        shapes[f"{bp}-mlp-shared_expert-wi_0-kernel"] = (*lp, emb, shared_mlp)
-        shapes[f"{bp}-mlp-shared_expert-wi_1-kernel"] = (*lp, emb, shared_mlp)
-        shapes[f"{bp}-mlp-shared_expert-wo-kernel"] = (*lp, shared_mlp, emb)
-        shapes[f"{bp}-mlp-shared_expert_gate-kernel"] = (*lp, emb, 1)
+        if n_experts == 0:
+            # Dense MLP: SwiGLU, HF uses intermediate_size (megatext mlp_dim).
+            dense_mlp = getattr(cfg, "intermediate_size", moe_mlp)
+            shapes[f"{bp}-mlp-wi_0-kernel"] = (*lp, emb, dense_mlp)
+            shapes[f"{bp}-mlp-wi_1-kernel"] = (*lp, emb, dense_mlp)
+            shapes[f"{bp}-mlp-wo-kernel"] = (*lp, dense_mlp, emb)
+        else:
+            # MoE
+            shapes[f"{bp}-mlp-routed_experts-gate-kernel"] = (*lp, emb, n_experts)
+            shapes[f"{bp}-mlp-routed_experts-wi_0"] = (*lp, n_experts, emb, moe_mlp)
+            shapes[f"{bp}-mlp-routed_experts-wi_1"] = (*lp, n_experts, emb, moe_mlp)
+            shapes[f"{bp}-mlp-routed_experts-wo"] = (*lp, n_experts, moe_mlp, emb)
+            shapes[f"{bp}-mlp-shared_expert-wi_0-kernel"] = (*lp, emb, shared_mlp)
+            shapes[f"{bp}-mlp-shared_expert-wi_1-kernel"] = (*lp, emb, shared_mlp)
+            shapes[f"{bp}-mlp-shared_expert-wo-kernel"] = (*lp, shared_mlp, emb)
+            shapes[f"{bp}-mlp-shared_expert_gate-kernel"] = (*lp, emb, 1)
 
     return shapes

--- a/src/megatext/models/qwen3.py
+++ b/src/megatext/models/qwen3.py
@@ -1028,8 +1028,24 @@ class Qwen3NextDecoderLayer(nnx.Module):
         rngs=rngs,
     )
 
-    # Instantiate our `Qwen3NextSparseMoeBlock`.
-    self.mlp = Qwen3NextSparseMoeBlock(config=cfg, mesh=self.mesh, quant=self.quant, rngs=rngs)
+    # FFN block: a plain dense MLP when num_experts == 0 (matching HF's dense
+    # Qwen3NextMLP path), otherwise the sparse MoE block (routed + shared).
+    if cfg.num_experts == 0:
+      self.mlp = MlpBlock(
+          in_features=cfg.emb_dim,
+          intermediate_dim=cfg.mlp_dim,
+          activations=cfg.mlp_activations,
+          intermediate_dropout_rate=cfg.dropout_rate,
+          dtype=cfg.dtype,
+          weight_dtype=cfg.weight_dtype,
+          config=cfg,
+          mesh=self.mesh,
+          quant=self.quant,
+          model_mode=model_mode,
+          rngs=rngs,
+      )
+    else:
+      self.mlp = Qwen3NextSparseMoeBlock(config=cfg, mesh=self.mesh, quant=self.quant, rngs=rngs)
 
   def __call__(
       self,
@@ -1084,13 +1100,16 @@ class Qwen3NextDecoderLayer(nnx.Module):
     hidden_states = self.post_attention_layernorm(hidden_states)
     hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
 
-    # Instantiate and call our `Qwen3NextSparseMoeBlock`.
-    mlp_output, load_balance_loss = self.mlp(hidden_states, deterministic=deterministic)
-
-    # We sow the load balancing loss so it can be collected and added to the total loss
-    # during training.
-    if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
-      self.sow("intermediates", "moe_lb_loss", load_balance_loss)
+    # Apply the FFN block. The dense MlpBlock returns a bare tensor; the sparse
+    # MoE block returns (output, load_balance_loss).
+    if isinstance(self.mlp, MlpBlock):
+      mlp_output = self.mlp(hidden_states, deterministic=deterministic)
+    else:
+      mlp_output, load_balance_loss = self.mlp(hidden_states, deterministic=deterministic)
+      # We sow the load balancing loss so it can be collected and added to the
+      # total loss during training.
+      if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
+        self.sow("intermediates", "moe_lb_loss", load_balance_loss)
 
     # Final residual connection (after the MoE block)
     layer_output = residual + mlp_output

--- a/src/megatext/utils/flops.py
+++ b/src/megatext/utils/flops.py
@@ -356,8 +356,12 @@ def get_dense_moe_layers(config):
     num_moe_layers = config.num_decoder_layers
     num_dense_layers = 0
   elif config.decoder_block == DecoderBlockType.QWEN3_NEXT:
-    num_moe_layers = config.num_decoder_layers
-    num_dense_layers = 0
+    if config.num_experts == 0:
+      num_moe_layers = 0
+      num_dense_layers = config.num_decoder_layers
+    else:
+      num_moe_layers = config.num_decoder_layers
+      num_dense_layers = 0
   else:
     raise ValueError("Currently we only support DeepSeek, Llama4, Gemma4, and Qwen3-Next calculation.")
 
@@ -585,10 +589,15 @@ def calculate_tflops_training_per_device(config, log=True):
   """Calculate training TFLOP"""
   # MLP flops
   if config.decoder_block == DecoderBlockType.QWEN3_NEXT:
-    # Qwen3-Next always uses the routed + shared expert MoE block, even with
-    # num_experts=1 (dense). The helper already multiplies by the number of
-    # layers, matching what the QWEN3_NEXT combination branch below expects.
-    total_ffn_flops = calculate_routed_and_shared_ffn_tflops_per_device(config)
+    if config.num_experts == 0:
+      # Dense qwen3-next: plain MLP per layer.
+      total_ffn_flops = (
+          calculate_ffn_mamtul_tflops_per_device(config, config.mlp_dim) * config.num_decoder_layers
+      )
+    else:
+      # Routed + shared expert MoE block. The helper already multiplies by the
+      # number of layers, matching what the QWEN3_NEXT combination branch below expects.
+      total_ffn_flops = calculate_routed_and_shared_ffn_tflops_per_device(config)
   elif config.num_experts > 1:
     # calculation based on dropless implementation
     if config.decoder_block in (DecoderBlockType.DEEPSEEK, DecoderBlockType.LLAMA4) or (

--- a/tests/unit/qwen3_next_conversion_test.py
+++ b/tests/unit/qwen3_next_conversion_test.py
@@ -1,0 +1,159 @@
+"""Qwen3-Next conversion mapping/shape tests (dense num_experts=0 + MoE)."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+from flax.traverse_util import flatten_dict
+from jax.sharding import Mesh
+
+from megatext.configs import pyconfig
+from megatext.conversion.models import ARCH_SPECS
+from megatext.conversion.models.qwen3_next import (
+    build_qwen3_next,
+    compute_qwen3_next_shapes,
+)
+from megatext.models import models
+from megatext.utils.sharding import create_device_mesh
+from tests.utils.test_helpers import get_decoupled_parallelism_overrides, get_test_config_path
+
+
+def _ns(obj):
+  if isinstance(obj, dict):
+    return SimpleNamespace(**{k: _ns(v) for k, v in obj.items()})
+  if isinstance(obj, list):
+    return [_ns(v) for v in obj]
+  return obj
+
+
+def _qwen3_next_hf_config(*, num_experts: int, num_layers: int = 8):
+  """Small qwen3-next HF-style config. num_experts=0 → dense, >0 → MoE."""
+  cfg = {
+      "model_type": "qwen3_next",
+      "tie_word_embeddings": False,
+      "hidden_size": 128,
+      "intermediate_size": 256,
+      "num_attention_heads": 4,
+      "num_key_value_heads": 2,
+      "head_dim": 32,
+      "vocab_size": 1024,
+      "num_hidden_layers": num_layers,
+      "full_attention_interval": 4,
+      "num_experts": num_experts,
+      "linear_num_key_heads": 4,
+      "linear_num_value_heads": 4,
+      "linear_key_head_dim": 32,
+      "linear_value_head_dim": 32,
+      "linear_conv_kernel_dim": 4,
+  }
+  if num_experts > 0:
+    cfg["moe_intermediate_size"] = 64
+    cfg["shared_expert_intermediate_size"] = 64
+  return _ns(cfg)
+
+
+def _unwrap_shape(value):
+  return getattr(value, "value", value).shape
+
+
+# ── Dense (num_experts=0) ───────────────────────────────────────────────────
+
+
+def test_build_qwen3_next_dense_maps_plain_swiglu():
+  hf = _qwen3_next_hf_config(num_experts=0, num_layers=8)
+  mapping = build_qwen3_next(ARCH_SPECS["qwen3_next"], hf, scan_layers=True)
+
+  assert mapping["params-decoder-layers-layers_0-mlp-wi_0-kernel"] == [
+      "model.layers.0.mlp.gate_proj.weight",
+      "model.layers.4.mlp.gate_proj.weight",
+  ]
+  assert mapping["params-decoder-layers-layers_0-mlp-wi_1-kernel"] == [
+      "model.layers.0.mlp.up_proj.weight",
+      "model.layers.4.mlp.up_proj.weight",
+  ]
+  assert mapping["params-decoder-layers-layers_0-mlp-wo-kernel"] == [
+      "model.layers.0.mlp.down_proj.weight",
+      "model.layers.4.mlp.down_proj.weight",
+  ]
+  # No MoE keys in the dense mapping.
+  assert not any("routed_experts" in str(k) or "shared_expert" in str(k) for k in mapping)
+
+
+def test_compute_qwen3_next_dense_shapes():
+  hf = _qwen3_next_hf_config(num_experts=0, num_layers=8)
+  shapes = compute_qwen3_next_shapes(hf, ARCH_SPECS["qwen3_next"], scan_layers=True)
+
+  # (n_stacked=2, emb=128, intermediate=256) and (n_stacked, intermediate, emb).
+  assert shapes["params-decoder-layers-layers_0-mlp-wi_0-kernel"] == (2, 128, 256)
+  assert shapes["params-decoder-layers-layers_0-mlp-wi_1-kernel"] == (2, 128, 256)
+  assert shapes["params-decoder-layers-layers_0-mlp-wo-kernel"] == (2, 256, 128)
+  # Attention/GDN shapes preserved: flat-2D out kernel, conv1d (conv_k, 1, conv_dim).
+  assert shapes["params-decoder-layers-layers_3-attention-attention-out-kernel"] == (2, 4 * 32, 128)
+  # conv1d kernel is (n_stacked, conv_k=4, 1, conv_dim); conv_k leads the matrix dims.
+  conv = shapes["params-decoder-layers-layers_0-attention-conv1d-kernel"]
+  assert conv[0] == 2 and conv[1] == 4 and conv[2] == 1
+
+
+# ── MoE (num_experts>0) regression: unchanged ──────────────────────────────
+
+
+def test_build_qwen3_next_moe_still_maps_routed_and_shared():
+  hf = _qwen3_next_hf_config(num_experts=512, num_layers=8)
+  mapping = build_qwen3_next(ARCH_SPECS["qwen3_next"], hf, scan_layers=True)
+
+  assert any("routed_experts" in str(k) for k in mapping)
+  assert any("shared_expert" in str(k) for k in mapping)
+  # Dense keys must NOT appear when MoE.
+  assert "params-decoder-layers-layers_0-mlp-wi_0-kernel" not in mapping
+
+
+# ── Linen param layout matches the dense conversion keys ────────────────────
+
+
+def _make_dense_runtime_config():
+  config_kwargs = {
+      **get_decoupled_parallelism_overrides(),
+      "run_name": "qwen3_next_conversion_test",
+      "enable_checkpointing": False,
+      "log_config": False,
+      "per_device_batch_size": 1.0,
+      "decoder_block": "qwen3_next",
+      "num_experts": 0,
+      "base_num_decoder_layers": 8,
+      "attention": "dot_product",
+      "max_target_length": 8,
+      "base_emb_dim": 128,
+      "base_mlp_dim": 256,
+      "base_num_query_heads": 4,
+      "base_num_kv_heads": 2,
+      "head_dim": 32,
+      "scan_layers": True,
+      "inhomogeneous_layer_cycle_interval": 4,
+  }
+  return pyconfig.initialize([sys.argv[0], get_test_config_path()], **config_kwargs)
+
+
+def test_dense_qwen3_next_linen_params_match_conversion_layout():
+  cfg = _make_dense_runtime_config()
+  mesh = Mesh(create_device_mesh(cfg), cfg.mesh_axes)
+  model = models.transformer_as_linen(config=cfg, mesh=mesh, quant=None, model_mode="train")
+  batch = cfg.global_batch_size_to_train_on
+  seq_len = cfg.max_target_length
+  ids = jnp.arange(batch * seq_len, dtype=jnp.int32).reshape(batch, seq_len) % cfg.vocab_size
+  seg = jnp.ones((batch, seq_len), dtype=jnp.int32)
+  pos = jnp.broadcast_to(jnp.arange(seq_len, dtype=jnp.int32)[None], (batch, seq_len))
+  rng = jax.random.PRNGKey(0)
+  variables = model.init(
+      {"params": rng, "aqt": rng, "dropout": rng}, ids, pos, seg, enable_dropout=False
+  )
+  flat = flatten_dict(variables["params"])
+
+  # Dense MLP present, MoE absent.
+  assert ("decoder", "layers", "layers_0", "mlp", "wi_0", "kernel") in flat
+  assert ("decoder", "layers", "layers_0", "mlp", "wi_1", "kernel") in flat
+  assert ("decoder", "layers", "layers_0", "mlp", "wo", "kernel") in flat
+  assert not any("routed_experts" in "/".join(map(str, k)) for k in flat)
+  assert not any("shared_expert" in "/".join(map(str, k)) for k in flat)


### PR DESCRIPTION
## Summary
megatext's qwen3-next hardcoded the sparse MoE FFN (routed E=1 + shared expert + sigmoid gate) even for the dense single-expert case. HF's `Qwen3NextDecoderLayer` uses a plain dense `Qwen3NextMLP` (`gate_proj`/`up_proj`/`down_proj`, `intermediate_size`) when `num_experts==0`. This matches that: **num_experts=0 ⇒ dense MLP on both sides**, dropping the routed+shared+gate overhead and giving a clean 1:1 HF conversion. `num_experts>0` keeps the MoE path unchanged (qwen3-next-moe, E=512).

## Changes
- **types.py**: `num_experts` `PositiveInt`→`NonNegativeInt`; drop the `num_experts==1` dense-mirror special-case; guard `num_experts==0` to qwen3-next only.
- **models/qwen3.py**: `Qwen3NextDecoderLayer` builds `MlpBlock` (dense) when `num_experts==0` else `Qwen3NextSparseMoeBlock`; `__call__` handles dense bare-tensor vs MoE `(output, load_balance_loss)` return.
- **conversion/models/qwen3_next.py**: build/transforms/compute_shapes branch on `num_experts==0` → dense `wi_0/wi_1/wo` ↔ `gate/up/down_proj` (like dense qwen3); MoE branch + all attention/GDN mappings unchanged.
- **configs/models/qwen3-next.yaml**: `num_experts: 0`.
- **flops.py**: dense FFN flop path for qwen3-next `num_experts==0`.
- **tests**: `qwen3_next_conversion_test.py` (dense mapping/shapes, MoE regression, linen-layout match).

## Verification (CPU)
- dense model builds with `mlp/wi_0/wi_1/wo` (no routed/shared), `mdn((0,),(-1,))`.
- 3-step dense train smoke (loss normal, no NaN, Muon).
- conversion dense + MoE-regression mapping/shape tests pass; existing swa conversion tests still pass.
- HF `num_experts=0` builds `Qwen3NextMLP` and forwards.
- dense MLP transform direction + forward `x@W^T == x@wi_0` exact (max|Δ|=0), roundtrip exact.

## Note
Requires retrain — the current MoE checkpoint (routed+shared+gate params) is structurally incompatible with the dense model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)