### PR TITLE
qwen3-next dense: mlp_dim 5120->10240 (~8.123B) + drop noisy tb log

### DIFF
--- a/gke/jobs/train/pretrain_qwen3_next_8b_stage1.yaml
+++ b/gke/jobs/train/pretrain_qwen3_next_8b_stage1.yaml
@@ -10,7 +10,7 @@ vars:
 config:
   model: qwen3-next
   base_emb_dim: 4096
-  base_mlp_dim: 5120
+  base_mlp_dim: 10240  # dense FFN width for ~8.123B params (matches the prior num_experts=1 MoE param count)
   base_num_query_heads: 32
   base_num_kv_heads: 8
   base_num_decoder_layers: 36

--- a/src/megatext/common/metric_logger.py
+++ b/src/megatext/common/metric_logger.py
@@ -276,7 +276,6 @@ class MetricLogger:
       full_log = step % self.config.log_period == 0
 
       if full_log and jax.process_index() == 0:
-        max_logging.log(f"To see full metrics 'tensorboard --logdir={self.config.tensorboard_dir}'")
         self.writer.flush()
 
   def write_metrics_to_managed_mldiagnostics(self, metrics, step):

--- a/src/megatext/utils/muon_utils.py
+++ b/src/megatext/utils/muon_utils.py
@@ -75,8 +75,8 @@ def transform_logic(path: Tuple[str, ...]) -> Optional[mdn]:
   # 1 Exclude parameters not suitable for Muon (scalar, embeddings, unembedding).
   # qwen3-next additions: A_log/dt_bias are per-head gating vectors, the
   # depthwise conv kernel is a bank of length-4 filters (not a matmul weight),
-  # and shared_expert_gate projects to a single logit — orthogonalizing a
-  # vector just renormalizes it.
+  # and shared_expert_gate projects to a single logit (emb x 1) — orthogonalizing
+  # a vector just renormalizes it.
   if _is_path_contain_any(
       ("scale", "bias", "embedding", "logits_dense", "A_log", "dt_bias", "conv1d", "shared_expert_gate"), path
   ):
@@ -90,8 +90,9 @@ def transform_logic(path: Tuple[str, ...]) -> Optional[mdn]:
   if _is_path_contain_any(("MoeBlock_0", "routed_experts"), path):
     if _is_path_contain_any(("wi_0", "wi_1", "wo"), path):
       return mdn((-2,), (-1,))
-    # qwen3-next single-expert router gate: [emb, L, 1] — a vector, not a
-    # matrix (and unused under the E=1 dense fast path); leave it to AdamW.
+    # Router gate produces routing logits ([emb, L, num_experts]); like the
+    # embedding / unembedding projections it is left to AdamW rather than
+    # orthogonalized, regardless of the expert count.
     if "routed_experts" in path and "gate" in path:
       return None
 


### PR DESCRIPTION
## Summary
After switching qwen3-next to a dense MLP (num_experts=0, #28), the FFN param count halved: the prior num_experts=1 MoE FFN was effectively two MLPs (routed E=1 + shared, each 5120 wide), while dense is a single 5120 MLP. This dropped the model from **8.123B → 5.858B**.

Widen `base_mlp_dim` 5120 → **10240** so the dense qwen3-next-8b matches the prior MoE param count (**8.123B**), keeping the dense-vs-MoE comparison fair. Qwen3-8B's `intermediate_size=12288` would overshoot to ~9.03B here, because qwen3-next's GDN (linear-attention) layers carry parameters the dense Qwen3 architecture doesn't.

Param sweep (emb=4096, 36 layers, measured via abstract param tree):
| base_mlp_dim | params |
|---|---|
| 5120 (was) | 5.858B |
| 8192 | 7.217B |
| **10240** | **8.123B** ✓ matches prior MoE |
| 12288 (Qwen3-8B) | 9.029B |

Also drop the per-`log_period` `"To see full metrics 'tensorboard --logdir=...'"` line in `metric_logger.py` (noisy at log_period=1); the writer flush is kept.

## Changes
- `gke/jobs/train/pretrain_qwen3_next_8b_stage1.yaml`: `base_mlp_dim` 5120 → 10240.
- `src/megatext/common/metric_logger.py`: remove the repeated tensorboard-hint log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)